### PR TITLE
Readme contains gem name that is incorrect, and support newer versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,19 +7,19 @@ Installation
 ----
 
 ```
-gem install analytics_ruby_mock
+gem install analytics-ruby-mock
 ```
 
 Usage
 ----
 
-Add `analytics_ruby_mock` to your gemfile:
+Add `analytics-ruby-mock` to your gemfile:
 
 ```ruby
-gem 'analytics_ruby_mock', group: :test
+gem 'analytics-ruby-mock', group: :test
 ```
 
-Require analytics_ruby_mock in your `spec_helper`:
+Require analytics-ruby-mock in your `spec_helper`:
 
 ```ruby
 require 'analytics_ruby_mock'

--- a/analytics-ruby-mock.gemspec
+++ b/analytics-ruby-mock.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'analytics-ruby-mock'
-  s.version     = '0.0.7'
+  s.version     = '0.1.0'
   s.summary     = "A mock for segment.io calls"
   s.description = "Capture all calls to segment.io and prevent them from being sent."
   s.authors     = ["Gavin Miller"]

--- a/lib/analytics_ruby_mock.rb
+++ b/lib/analytics_ruby_mock.rb
@@ -1,4 +1,4 @@
-module AnalyticsRuby
+module Analytics
   module ClassMethods
     attr_accessor :track_calls, :identify_calls, :alias_calls
 
@@ -64,7 +64,7 @@ module AnalyticsRuby
 
     def debug_message(method, options = nil)
       if @debug
-        puts "Mock of AnalyticsRuby called #{method.to_s} #{options.present? ? "with: #{options}" : ""}"
+        puts "Mock of Analytics called #{method.to_s} #{options.present? ? "with: #{options}" : ""}"
       end
     end
   end

--- a/spec/lib/analytics_ruby_mock_spec.rb
+++ b/spec/lib/analytics_ruby_mock_spec.rb
@@ -1,8 +1,6 @@
 require 'analytics_ruby_mock'
 
-Analytics = AnalyticsRuby
-
-describe AnalyticsRuby do
+describe Analytics do
   after :each do
     Analytics.clear
   end


### PR DESCRIPTION
1. Gem name is incorrect, fixing Readme
2. Updates version to `0.1.0` as contains backwards incompatible change that supports the newer SegmentIO versions that use `Analytics` instead of `AnalyticsRuby` for the class name.

Thanks, these were necessary to get it working for me.
